### PR TITLE
Chore: update badges in Readme to new org. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ Documentation sources for [nightwatchjs.org](http://nightwatchjs.org) website.
 
 Nightwatchjs is a UI automated testing framework powered by [Node.js](http://nodejs.org/). It uses the [Selenium WebDriver API](https://code.google.com/p/selenium/wiki/JsonWireProtocol).
 
-[![Build Status](https://travis-ci.org/beatfactor/nightwatch.png?branch=master)](https://travis-ci.org/beatfactor/nightwatch) [![NPM version](https://badge.fury.io/js/nightwatch.png)](http://badge.fury.io/js/nightwatch) [![Coverage Status](https://coveralls.io/repos/beatfactor/nightwatch/badge.png?branch=master)](https://coveralls.io/r/beatfactor/nightwatch?branch=master)
-
+[![Build Status](https://travis-ci.org/nightwatchjs/nightwatch.svg?branch=master)](https://travis-ci.org/nightwatchjs/nightwatch)
+[![NPM version](https://badge.fury.io/js/nightwatch.png)](http://badge.fury.io/js/nightwatch)
+[![Coverage Status](https://coveralls.io/repos/github/nightwatchjs/nightwatch/badge.svg?branch=master)](https://coveralls.io/github/nightwatchjs/nightwatch?branch=master)
 ***
 
 #### [Homepage](http://nightwatchjs.org) | [Developer Guide](http://nightwatchjs.org/guide) | [API Reference](http://nightwatchjs.org/api)
@@ -47,4 +48,3 @@ Extending Nightwatch
   ├── Custom assertions
   └── Custom reporter
 ```
-


### PR DESCRIPTION
Hi @beatfactor,

Currently:
<img width="569" alt="nightwatch-docs-dont-inspire-much-with-broken-badges" src="https://cloud.githubusercontent.com/assets/194400/16504883/19bc13f6-3f12-11e6-992a-9b45a5259524.png">

This PR updates badges to:

[![Build Status](https://travis-ci.org/nightwatchjs/nightwatch.svg?branch=master)](https://travis-ci.org/nightwatchjs/nightwatch) [![NPM version](https://badge.fury.io/js/nightwatch.png)](http://badge.fury.io/js/nightwatch) [![Coverage Status](https://coveralls.io/repos/github/nightwatchjs/nightwatch/badge.svg?branch=master)](https://coveralls.io/github/nightwatchjs/nightwatch?branch=master)

fixes https://github.com/nightwatchjs/nightwatch-docs/issues/35