### PR TITLE
Clarify start_session

### DIFF
--- a/gettingstarted/browser-setup/chromedriver.md
+++ b/gettingstarted/browser-setup/chromedriver.md
@@ -41,6 +41,8 @@ This requires a bit more configuration:<br><br>
 }
 </code></pre>
 
+Note that you still need to keep `start_session` set to true, if you intend to interact with the Selenium server (e.g. issue Webdriver commands).
+
 
 ##### 2) Configure the port and default path prefix.
 


### PR DESCRIPTION
For the standalone chromedriver setup, people might also go ahead and
set start_session to false apart from the start_process. It might be
useful to point this out.

Related bug:
https://github.com/nightwatchjs/nightwatch/issues/1163