### PR TITLE
Fix minor table formatting issue.

### DIFF
--- a/guide/running-tests/runner-options.md
+++ b/guide/running-tests/runner-options.md
@@ -105,7 +105,6 @@ The test runner supports a number of run-time options to be passed to. To view a
        <td></td>
        <td>Retries failed or errored testsuites (test modules) up to the specified number of times. Retrying a testsuite will also retry the `before` and `after` hooks (in addition to the global beforeEach and afterEach respectively), if any are defined on the testsuite.</td>
      </tr>
-
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
Currently, the table body closing tag is oddly placed which leads to it being interpreted as a code line. This commit fixes that minor issue.