### PR TITLE
Changed Deprecated Lines in Examples

### DIFF
--- a/guide/using-nightwatch/write-tests.md
+++ b/guide/using-nightwatch/write-tests.md
@@ -12,8 +12,7 @@ module.exports = {
       .url('http://www.google.com')
       .waitForElementVisible('body', 1000)
       .setValue('input[type=text]', 'nightwatch')
-      .waitForElementVisible('button[name=btnG]', 1000)
-      .click('button[name=btnG]')
+      .keys(browser.Keys.ENTER)
       .pause(1000)
       .assert.containsText('#main', 'Night Watch')
       .end();
@@ -35,12 +34,11 @@ module.exports = {
       .url('http://www.google.com')
       .waitForElementVisible('body', 1000)
       .setValue('input[type=text]', 'nightwatch')
-      .waitForElementVisible('button[name=btnG]', 1000)
+      .keys(browser.Keys.ENTER)
   },
 
   'step two' : function (browser) {
     browser
-      .click('button[name=btnG]')
       .pause(1000)
       .assert.containsText('#main', 'Night Watch')
       .end();
@@ -56,8 +54,7 @@ this.demoTestGoogle = function (browser) {
     .url('http://www.google.com')
     .waitForElementVisible('body', 1000)
     .setValue('input[type=text]', 'nightwatch')
-    .waitForElementVisible('button[name=btnG]', 1000)
-    .click('button[name=btnG]')
+    .keys(browser.Keys.ENTER)
     .pause(1000)
     .assert.containsText('#main', 'The Night Watch')
     .end();

--- a/guide/working-with-page-objects/po-mixins.md
+++ b/guide/working-with-page-objects/po-mixins.md
@@ -24,7 +24,7 @@ module.exports = {
       selector: 'input[type=text]'
     },
     submitButton: {
-      selector: 'button[name=btnG]'
+      selector: 'input[name=btnK]'
     }
   }
 };


### PR DESCRIPTION
Google changed their main search button in August 2017, to an input field with a different name.
button[name=btnG]  --> input[name=btnK]

The Examples on the Mainpage would also be needing this change.