### PR TITLE
docs: use () instead of _ for arrow functions

### DIFF
--- a/guide/running-tests/programmatic-api.md
+++ b/guide/running-tests/programmatic-api.md
@@ -39,8 +39,8 @@ Nightwatch.cli(function(argv) {
   runner
     .setup()
     .startWebDriver()
-    .then(_ => runner.runTests())
-    .then(_ => runner.stopWebDriver())
+    .then(() => runner.runTests())
+    .then(() => runner.stopWebDriver())
     .catch(err => console.error(err));
 });
 </code></pre></div>


### PR DESCRIPTION
the _ does not appear in documentation, making the code fail if you copy paste. Using a placeholder will also trigger eslint warning for some people while () shouldn't