### PR TITLE
fixed markdown in commands, assertions, page and expect

### DIFF
--- a/api/assertions.md
+++ b/api/assertions.md
@@ -27,12 +27,10 @@ And thus, assertions like `elementNotPresent`, `cssClassNotPresent`, `hidden` ar
 module.exports = {
   demoTest: function(browser) {
     browser.init();
-    
     browser
       .assert.not.elementPresent('.not_present') // previously .assert.elementNotPresent()
       .assert.not.visible('.non_visible') // previously .assert.hidden()
       .assert.not.urlContains('http://');
-    
     // ...
   }
 }

--- a/api/commands.md
+++ b/api/commands.md
@@ -10,8 +10,7 @@ Some of them are basic commands (such as `url` and `execute`) and others are int
 ### Callback function
 Each method below allows a `callback` argument to be passed as the last argument. The callback function will then be called after the command is completed with the main API (`browser`) as the context and the response object as argument.
 
-<div class="sample-test"><pre data-language="javascript"><code class="language-javascript">
-this.demoTest = function (browser) {
+<div class="sample-test"><pre data-language="javascript"><code class="language-javascript">this.demoTest = function (browser) {
   browser.click("#main ul li a.first", function(result) {
     this.assert.ok(browser === this);
     this.assert.ok(typeof result == "object");
@@ -20,8 +19,7 @@ this.demoTest = function (browser) {
 
 ### Promises in callbacks
 If the callback happens to return a `Promise`, the test runner will wait for the promise to settle (i.e. resolve or reject) before continuing with the rest of the commands.
-<div class="sample-test"><pre data-language="javascript"><code class="language-javascript">
-module.exports = {
+<div class="sample-test"><pre data-language="javascript"><code class="language-javascript">module.exports = {
   demoTest: function (browser) {
     browser
       .init()
@@ -35,13 +33,11 @@ module.exports = {
       })
       .click('#login button');
   },
-  
   demoTestAsync: async function(browser) {
     await browser.init();
     const text = await browser.getText("#main ul li", function(result) {
-      return Promise.resolve(resolve.value);
+      return Promise.resolve(result.value);
     });              
-    
     console.log('text', text);
   }
 };</code></pre></div>

--- a/api/expect.md
+++ b/api/expect.md
@@ -9,7 +9,6 @@ It uses a chain-able language to construct assertions given an element specified
   // start with identifying the element
   // and then assert the element is present
   browser.expect.element('#main').to.be.present;
-
   // or assert the element is visible
   browser.expect.element('#main').to.be.visible;
 };</code></pre></div>
@@ -40,9 +39,7 @@ The following are provided as chainable getters to improve the readability of yo
 <div class="sample-test">
 <pre class="line-numbers" data-language="javascript"><code class="language-javascript">this.demoTest = function (browser) {
   browser.expect.element('#main').text.to.equal('The Night Watch');
-
   browser.expect.element('#main').text.to.contain('The Night Watch');
-
   browser.expect.element('#main').to.have.css('display').which.equals('block');
 };</code></pre>
 </div>
@@ -56,7 +53,6 @@ The following are provided as chainable getters to improve the readability of yo
 <div class="sample-test">
 <pre class="line-numbers" data-language="javascript"><code class="language-javascript">this.demoTest = function (browser) {
   browser.expect.element('#main').text.to.endWith('Watch');
-
   browser.expect.element('#main').text.to.startWith('The');
 };</code></pre>
   </div>
@@ -69,9 +65,7 @@ The following are provided as chainable getters to improve the readability of yo
   <div class="sample-test">
 <pre class="line-numbers" data-language="javascript"><code class="language-javascript">this.demoTest = function (browser) {
   browser.expect.element('#main').text.to.not.equal('The Night Watch');
-
   browser.expect.element('#main').text.to.not.contain('The Night Watch');
-
   browser.expect.element('#main').to.have.css('display').which.does.not.equal('block');
 };</code></pre>
   </div>
@@ -87,7 +81,6 @@ The following are provided as chainable getters to improve the readability of yo
 <div class="sample-test">
 <pre data-language="javascript"><code class="language-javascript">this.demoTest = function (browser) {
   browser.expect.element('#main').text.to.contain('The Night Watch').before(1000);
-
   browser.expect.element('#main').text.to.not.contain('The Night Watch').after(500);
 };</code></pre>
   </div>

--- a/api/page.md
+++ b/api/page.md
@@ -11,8 +11,7 @@ Page objects provide an additional layer of abstraction for test case creation. 
   },
   elements: {
     // shorthand, specifies selector
-    mySubmitButton: 'input[type=submit]'
-
+    mySubmitButton: 'input[type=submit]',
     // full
     myTextInput: {
       selector: 'input[type=text]',
@@ -30,7 +29,6 @@ Page objects provide an additional layer of abstraction for test case creation. 
   props: {
     myPauseTime: 1000
   },
-
   sections: {
     myFooterSection: {
       selector: '#my-footer',
@@ -125,7 +123,6 @@ Every time a factory function like MyPage above is called, a new instance of the
     </tr>
     </thead>
     <tbody>
-
     <tr>
       <td>`api`</td>
       <td>`Object`</td>
@@ -151,13 +148,11 @@ Every time a factory function like MyPage above is called, a new instance of the
       <td>`Object`</td>
       <td>A map of Sections objects defined for the page object. This will only contain sections within the page object module's root `sections` definition. Nested sections are accessible through their parent section's own `section` reference.</td>
     </tr>
-
     <tr>
       <td>`url`</td>
       <td>`string`|`Function`</td>
       <td>The url value from the page object module, either a string or a function depending on how it was defined there.</td>
     </tr>
-
     </tbody>
   </table>
 </div>
@@ -193,13 +188,11 @@ The Nightwatch command and assertions API is inherited by page objects.
     </tr>
     </thead>
     <tbody>
-
     <tr>
       <td>`commands`</td>
       <td>Array</td>
       <td>A list of objects containing functions to represent methods added to the page object instance.</td>
     </tr>
-
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
The above mentioned md files had some odd looking code blocks. These changes are to make them look better when viewed on GitHub.

The second fix is in commands.md where instead of `result.value` it says `resolve.value` 