### PR TITLE
Add more info on desired edge version.

### DIFF
--- a/guide/browser-drivers-setup/edgedriver.md
+++ b/guide/browser-drivers-setup/edgedriver.md
@@ -5,7 +5,7 @@
 
 #### Download
 
-Download the desired version from the [Microsoft Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/) downloads page. After the download completes, extract the zip archive and place `msedgedriver` to your preferred location inside the project.
+Download the version matching your Edge browser's version from the [Microsoft Edge WebDriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/) downloads page. After the download completes, extract the zip archive and place `msedgedriver` to your preferred location inside the project.
 
 #### Standalone Usage
 


### PR DESCRIPTION
It is not very often clear to the user which version of Edge webdriver they need to download. So, made a little change so that they know that the webdriver version should match the version of the Edge browser they have on their system.