### PR TITLE
Fixing incorrect path to ecosia.js

### DIFF
--- a/guide/quickstarts/create-and-run-a-nightwatch-test.md
+++ b/guide/quickstarts/create-and-run-a-nightwatch-test.md
@@ -105,7 +105,7 @@ If you are running from a Mac, safaridriver is present by default but must be en
 
 Once your setup is done, you can run tests with this command
 
-<pre><code class="language-bash">npx nightwatch tests/ecosia.js --env safari</code></pre>
+<pre><code class="language-bash">npx nightwatch tests/specs/basic/ecosia.js --env safari</code></pre>
 
 The output should look similar to this:
 

--- a/guide/quickstarts/create-and-run-a-test-with-selenium-server.md
+++ b/guide/quickstarts/create-and-run-a-test-with-selenium-server.md
@@ -108,13 +108,13 @@ If you are running from a Mac, safaridriver is present by default but must be en
 Once your setup is done, you can run tests with this command
 
 ##### Firefox
-<pre><code class="language-bash">npx nightwatch tests/ecosia.js --env selenium.firefox</code></pre>
+<pre><code class="language-bash">npx nightwatch tests/specs/basic/ecosia.js --env selenium.firefox</code></pre>
 
 ##### Chrome
-<pre><code class="language-bash">npx nightwatch tests/ecosia.js --env selenium.chrome</code></pre>
+<pre><code class="language-bash">npx nightwatch tests/specs/basic/ecosia.js --env selenium.chrome</code></pre>
 
 ##### Safari
-<pre><code class="language-bash">npx nightwatch tests/ecosia.js --env selenium.safari</code></pre>
+<pre><code class="language-bash">npx nightwatch tests/specs/basic/ecosia.js --env selenium.safari</code></pre>
 
 The output should look similar to this:
 <pre class="hide-indicator" ><code class="language-bash">


### PR DESCRIPTION
In the recent installations of Nightwatch v2.3.x the ecosia file is available in the `tests/specs/basic/` folder.