### PR TITLE
Added LambdaTest configurations in running test with cloud provider

### DIFF
--- a/guide/quickstarts/create-and-run-a-test-with-cloud-providers.md
+++ b/guide/quickstarts/create-and-run-a-test-with-cloud-providers.md
@@ -81,46 +81,46 @@ If you are trying to run Nightwatch on LambdaTest for an existing project, you w
     ...,
     test_settings: {
         ...,
-            lambdatest: {
+        lambdatest: {
             selenium: {
                 host: 'hub.lambdatest.com',
                 port: 443
-              },
-            "username": '${LAMBDATEST_USERNAME}',
-            "access_key": '${LAMBDATEST_ACCESS_KEY}',
             },
-             // More info on configuring capabilities can be found on:
-            // https://www.lambdatest.com/capabilities-generator/
-            "lambdatest.chrome": {
+            'username': '${LAMBDATEST_USERNAME}',
+            'access_key': '${LAMBDATEST_ACCESS_KEY}',
+        },
+        // More info on configuring capabilities can be found on:
+        // https://www.lambdatest.com/capabilities-generator/
+        'lambdatest.chrome': {
             extends: 'lambdatest',
             desiredCapabilities: {
                 browserName: 'chrome',
                 'LT:Options': {
-                    "platformName": "Windows 10",
-                    "browserVersion": "108.0",
-                    "project": 'Project',
-                    }
-                 }
-            },
+                    'platformName': 'Windows 10',
+                    'browserVersion': '108.0',
+                    'project': 'Project',
+                }
+            }
+        },
 
-            "lambdatest.firefox": {
+        'lambdatest.firefox': {
             extends: 'lambdatest',
             desiredCapabilities: {
                 browserName: 'firefox',
                 'LT:Options': {
-                    "platformName": "Windows 10",
-                    "browserVersion": "108.0",
-                    "project": 'Untitled',
-                    }
-                 }
-            },
+                    'platformName': 'Windows 10',
+                    'browserVersion': '108.0',
+                    'project': 'Untitled',
+                }
+            }
+        },
         ...
     }
 }
 
 </code></pre></div>
 
-Once you have added LambdaTest configurations is present in the `nightwatch.conf.js` replace the LambdaTest username and access_key with your credentials and you are ready to run your tests on the LambdaTest Cloud grid.
+Once you have added LambdaTest configurations in the `nightwatch.conf.js` replace the LambdaTest username and access_key with your credentials and you are ready to run your tests on the LambdaTest Cloud grid.
 
 You can also configure and add your desired capabilities with the help of [automation capabilty generator](https://www.lambdatest.com/capabilities-generator/).
 

--- a/guide/quickstarts/create-and-run-a-test-with-cloud-providers.md
+++ b/guide/quickstarts/create-and-run-a-test-with-cloud-providers.md
@@ -15,7 +15,7 @@ If you are installing Nightwatch using the CLI utility and you select to run on 
 If you are trying to run Nightwatch on BrowserStack for an existing project, you will have to add a `browserstack` block in the `nightwatch.conf.js` file as a child property to `test_settings`.
 
 <div class="sample-test">
-<i>nightwatch.json</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
+<i>nightwatch.conf.js</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
     ...,
     test_settings: {
         ...,
@@ -72,6 +72,58 @@ If you are trying to run Nightwatch on BrowserStack for an existing project, you
 
 Once the BrowerStack block is present in the Nightwatch configuration file, replace the BrowserStack username and access key with your credentials and you are ready to run your tests on the BrowserStack infrastructure.
 
+### Running on LambdaTest
+
+If you are trying to run Nightwatch on LambdaTest for an existing project, you will have to add a `lambdatest` block in the `nightwatch.conf.js` file as a child property to `test_settings`.
+
+<div class="sample-test">
+<i>nightwatch.conf.js</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
+    ...,
+    test_settings: {
+        ...,
+            lambdatest: {
+            selenium: {
+                host: 'hub.lambdatest.com',
+                port: 443
+              },
+            "username": '${LAMBDATEST_USERNAME}',
+            "access_key": '${LAMBDATEST_ACCESS_KEY}',
+            },
+             // More info on configuring capabilities can be found on:
+            // https://www.lambdatest.com/capabilities-generator/
+            "lambdatest.chrome": {
+            extends: 'lambdatest',
+            desiredCapabilities: {
+                browserName: 'chrome',
+                'LT:Options': {
+                    "platformName": "Windows 10",
+                    "browserVersion": "108.0",
+                    "project": 'Project',
+                    }
+                 }
+            },
+
+            "lambdatest.firefox": {
+            extends: 'lambdatest',
+            desiredCapabilities: {
+                browserName: 'firefox',
+                'LT:Options': {
+                    "platformName": "Windows 10",
+                    "browserVersion": "108.0",
+                    "project": 'Untitled',
+                    }
+                 }
+            },
+        ...
+    }
+}
+
+</code></pre></div>
+
+Once you have added LambdaTest configurations is present in the `nightwatch.conf.js` replace the LambdaTest username and access_key with your credentials and you are ready to run your tests on the LambdaTest Cloud grid.
+
+You can also configure and add your desired capabilities with the help of [automation capabilty generator](https://www.lambdatest.com/capabilities-generator/).
+
 ### Running on Sauce Labs
 
 If you select Sauce Labs as the cloud provider while setting up Nightwatch via the CLI utility, the test settings will be automatically added.
@@ -79,7 +131,7 @@ If you select Sauce Labs as the cloud provider while setting up Nightwatch via t
 If you are trying to run Nightwatch on Sauce Labs for an existing project, you will have to add the following block in the `nightwatch.conf.js` file as shown below.
 
 <div class="sample-test">
-<i>nightwatch.json</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
+<i>nightwatch.conf.js</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
     ...,
     test_settings: {
         ...,
@@ -135,7 +187,7 @@ If you are installing Nightwatch using the `create-nightwatch` utility and you s
 If you are trying to set this up for an existing project, you will have to add the following block in the `nightwatch.conf.js` file under the `test_settings` property as shown below.
 
 <div class="sample-test">
-<i>nightwatch.json</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
+<i>nightwatch.conf.js</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
     ...,
     test_settings : {
         ...,


### PR DESCRIPTION
Hey @AutomatedTester, @beatfactor,
Adding the configuration for running the Nightwatch test on LambdaTest

- Edits in the quickstart guide Run a Nightwatch test with a cloud provider section. (Tested on Nightwatch 2.4v)
- Made corrections in BrowserStack and SauceLabs configuration - changed the file name from `nightwatch.json` to `nightwatch.conf.js`

As a result, users can run their tests on the cloud on LambdaTest.

Issue #217 