### PR TITLE
Fix ios mobile-helper installation code

### DIFF
--- a/guide/mobile-app-testing/installation.md
+++ b/guide/mobile-app-testing/installation.md
@@ -208,7 +208,7 @@ And done! 🎉 Your Android setup is now complete.
 <b>Step 1</b></br>
 Go the to the Nightwatch project directory and run the following command
 
-<pre style="max-width: 800px; border-radius: 10px; padding: 10px 20px"><code class="language-bash" style="font-size: 20px">npx @nightwatch/mobile-helper ios --setups
+<pre style="max-width: 800px; border-radius: 10px; padding: 10px 20px"><code class="language-bash" style="font-size: 20px">npx @nightwatch/mobile-helper ios --setup
 </code></pre>
 
 <b>Step 2</b></br>


### PR DESCRIPTION
The error is occurred after execution the following code from documentation:
`npx @nightwatch/mobile-helper ios --setups`
Error text:
`unknown option(s) passed: setups`
The correct name of parameter is `---setup`.