### PR TITLE
Update use-slack-reporter.md

### DIFF
--- a/guide/reporters/use-slack-reporter.md
+++ b/guide/reporters/use-slack-reporter.md
@@ -68,6 +68,7 @@ Make sure your `globals.js` is configured already; if not, please follow the [se
    // function or message string
    slack_message: function(results, options) {
      // Message payload or string  
+
      return {
        text: 'Test completed, passed ' + results.passed + ', failed ' + results.failed,
        username: 'Nightwatch',


### PR DESCRIPTION
on line 72 "return" is considered part of the comment preceding it, and it needs to be uncommented. See https://nightwatchjs.org/guide/reporters/use-slack-reporter.html for comparison