### PR TITLE
fix: wrong next-page navigation

### DIFF
--- a/guide/mobile-app-testing/selectors.md
+++ b/guide/mobile-app-testing/selectors.md
@@ -66,7 +66,7 @@ Now that you understand selectors, you can use them to write commands & assertio
   </div>
   <div class="doc-pagination justify-content-end pt-40">
   <div class="next">
-    <a href="https://nightwatchjs.org/guide/mobile-app-testing/selectors.html">
+    <a href="https://nightwatchjs.org/guide/mobile-app-testing/commands.html">
         <div class="d-flex flex-column"><span class="smallT">Next Page</span><span class="bigT">Mobile App Commands</span></div>
         <span>→</span>
     </a>


### PR DESCRIPTION
# description:
when you are on https://nightwatchjs.org/guide/mobile-app-testing/selectors.html page,
you are unable to navigate to next step/page (Mobile App Commands page)

# expected result:
user should be able to navigate to next page using next button

# actual result:
user unable to navigate to next page