### PR TITLE
Fix links in "See also" section of the API docs.

### DIFF
--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -3,7 +3,7 @@ import {sep, join, basename, resolve, extname} from 'node:path';
 
 const {
   NIGHTWATCH_VERSION = '3.5.0',
-  BASE_URL = 'https://nightwatchjs.org/',
+  BASE_URL = 'https://nightwatchjs.org',
   MD_DOCS_FOLDER =  './docs',
   API_DOCS_FOLDER = resolve('../nightwatch/lib/api'),
   EXAMPLES_FOLDER = 'node_modules/nightwatch-examples/tests'

--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -16,7 +16,7 @@ export default {
 
     ]
   },
-  
+
   session: {
     enable_prefetch: false,
     disable_spa: false

--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -3,7 +3,7 @@ import {sep, join, basename, resolve, extname} from 'node:path';
 
 const {
   NIGHTWATCH_VERSION = '3.5.0',
-  BASE_URL = 'https://nightwatchjs.org',
+  BASE_URL = 'https://nightwatchjs.org/',
   MD_DOCS_FOLDER =  './docs',
   API_DOCS_FOLDER = resolve('../nightwatch/lib/api'),
   EXAMPLES_FOLDER = 'node_modules/nightwatch-examples/tests'

--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -3,7 +3,7 @@ import {sep, join, basename, resolve, extname} from 'node:path';
 
 const {
   NIGHTWATCH_VERSION = '3.5.0',
-  BASE_URL = 'https://nightwatchjs.org',
+  BASE_URL = 'https://nightwatchjs.org/',
   MD_DOCS_FOLDER =  './docs',
   API_DOCS_FOLDER = resolve('../nightwatch/lib/api'),
   EXAMPLES_FOLDER = 'node_modules/nightwatch-examples/tests'
@@ -16,7 +16,6 @@ export default {
 
     ]
   },
-
   session: {
     enable_prefetch: false,
     disable_spa: false

--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -16,6 +16,7 @@ export default {
 
     ]
   },
+  
   session: {
     enable_prefetch: false,
     disable_spa: false

--- a/src/includes/api-method.ejs
+++ b/src/includes/api-method.ejs
@@ -134,7 +134,7 @@ npx nightwatch <%- method.exampleLink %></code></pre>
                 <% if (link.startsWith('http')) { %>
                     <li><code><a href="<%- link %>"><%= link %></a></code></li>
                 <% } else { %>
-                    <li><code><a href="<%- appSettings.baseUrl -%>/api/<%- link.split('.').join('/') %>.html"><%= link %></a></code></li>
+                    <li><code><a href="/api/<%- link.split('.').join('/') %>.html"><%= link %></a></code></li>
                 <% } %>
             <% } %>
         </ul>

--- a/src/includes/api-method.ejs
+++ b/src/includes/api-method.ejs
@@ -134,7 +134,7 @@ npx nightwatch <%- method.exampleLink %></code></pre>
                 <% if (link.startsWith('http')) { %>
                     <li><code><a href="<%- link %>"><%= link %></a></code></li>
                 <% } else { %>
-                    <li><code><a href="<%- appSettings.baseUrl.replace(/\/$/, '') -%>/api/<%- link.split('.').join('/') %>.html"><%= link %></a></code></li>
+                    <li><code><a href="<%- appSettings.baseUrl -%>/api/<%- link.split('.').join('/') %>.html"><%= link %></a></code></li>
                 <% } %>
             <% } %>
         </ul>


### PR DESCRIPTION
@garg3133 Review Requested.

I have been investigating to find any hard-coded redirect but there are none and entire docs have been updated with `/guide`.

Afterwards, I found that there is if-else logic running for "See Also" section at, `nightwatch-docs/src/includes/api-method.ejs`

In that, the line, `<li><code><a href="<%- appSettings.baseUrl.replace(/\/$/, '') -%>/api/<%- link.split('.').join('/') %>.html"><%= link %></a></code></li>` generates link accordingly.

Now, after many workarounds, I cannot seem to budge the extra two dots that, `appSettings.baseUrl.replace(/\$/,'')` is appending after ".org" domain.

I tried:
[-] Slicing after replace with (0,-2), but instead of removing double dots, it gives out: https://nightwatchjs.o../<other-parts-of-url>
[-] Writing new logic: Gives out same result

I found that, replace() method is creating the problems. Simply removing it, works. Additionally, I added "/" in the BASE_URL in postdoc config.

Do tell me if this is not right, or should I seek another way to solve the problem?