### PR TITLE
#293 Fix links in "W3C Webdriver Spec" section of the API docs

### DIFF
--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -6,7 +6,8 @@ const {
   BASE_URL = 'https://nightwatchjs.org',
   MD_DOCS_FOLDER =  './docs',
   API_DOCS_FOLDER = resolve('../nightwatch/lib/api'),
-  EXAMPLES_FOLDER = 'node_modules/nightwatch-examples/tests'
+  EXAMPLES_FOLDER = 'node_modules/nightwatch-examples/tests',
+  WEBDRIVER_SPEC = 'https://www.w3.org/TR/webdriver',
 } = env;
 
 export default {
@@ -87,6 +88,7 @@ export default {
   appSettings: {
     version: NIGHTWATCH_VERSION,
     baseUrl: BASE_URL,
+    webdriverSpec : WEBDRIVER_SPEC,
     apiRepoUrl: 'https://github.com',
     githubRepo: 'nightwatchjs/nightwatch',
     docsRepoUrl: 'https://github.com/nightwatchjs/nightwatch-docs/blob/',

--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -7,7 +7,7 @@ const {
   MD_DOCS_FOLDER =  './docs',
   API_DOCS_FOLDER = resolve('../nightwatch/lib/api'),
   EXAMPLES_FOLDER = 'node_modules/nightwatch-examples/tests',
-  WEBDRIVER_SPEC = 'https://w3c.github.io/webdriver',
+  WEBDRIVER_SPEC_URL = 'https://w3c.github.io/webdriver',
 } = env;
 
 export default {
@@ -88,7 +88,7 @@ export default {
   appSettings: {
     version: NIGHTWATCH_VERSION,
     baseUrl: BASE_URL,
-    webdriverSpec : WEBDRIVER_SPEC,
+    webdriverSpecUrl : WEBDRIVER_SPEC_URL,
     apiRepoUrl: 'https://github.com',
     githubRepo: 'nightwatchjs/nightwatch',
     docsRepoUrl: 'https://github.com/nightwatchjs/nightwatch-docs/blob/',

--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -7,7 +7,7 @@ const {
   MD_DOCS_FOLDER =  './docs',
   API_DOCS_FOLDER = resolve('../nightwatch/lib/api'),
   EXAMPLES_FOLDER = 'node_modules/nightwatch-examples/tests',
-  WEBDRIVER_SPEC = 'https://www.w3.org/TR/webdriver',
+  WEBDRIVER_SPEC = 'https://w3c.github.io/webdriver',
 } = env;
 
 export default {

--- a/src/includes/api-method.ejs
+++ b/src/includes/api-method.ejs
@@ -142,12 +142,12 @@ npx nightwatch <%- method.exampleLink %></code></pre>
 
     <% if (method.link) { %>
         <h3>W3C WebDriver spec</h3>
-        <ul class="webdriver-spec-related-links">
+        <ul class="webdriver-spec-link">
             <% if (method.link.startsWith('http')) { %>
-                <li><code><a href="<%- link %>"><%= link %></a></code></li>
-           <% } else { %>
-            <li><code><a href="<%- appSettings.webdriverSpec -%><%= method.link %>" target="_blank"><%- method.link %></a></code></li>
-           <% } %>
+                <li><code><a href="<%- method.link %>" target="_blank"><%= method.link %></a></code></li>
+            <% } else { %>
+                <li><code><a href="<%- appSettings.webdriverSpecUrl + method.link %>" target="_blank"><%= method.link %></a></code></li>
+            <% } %>            
         </ul>
     <% } %>
 <% } %>

--- a/src/includes/api-method.ejs
+++ b/src/includes/api-method.ejs
@@ -143,7 +143,7 @@ npx nightwatch <%- method.exampleLink %></code></pre>
     <% if (method.link) { %>
         <h3>W3C WebDriver spec</h3>
         <ul>
-            <li><code><a href="<%= method.link %>" target="_blank"><%- method.link %></a></code></li>
+            <li><code><a href="<%- appSettings.webdriverSpec -%><%= method.link %>" target="_blank"><%- method.link %></a></code></li>
         </ul>
     <% } %>
 <% } %>

--- a/src/includes/api-method.ejs
+++ b/src/includes/api-method.ejs
@@ -142,8 +142,12 @@ npx nightwatch <%- method.exampleLink %></code></pre>
 
     <% if (method.link) { %>
         <h3>W3C WebDriver spec</h3>
-        <ul>
+        <ul class="webdriver-spec-related-links">
+            <% if (method.link.startsWith('http')) { %>
+                <li><code><a href="<%- link %>"><%= link %></a></code></li>
+           <% } else { %>
             <li><code><a href="<%- appSettings.webdriverSpec -%><%= method.link %>" target="_blank"><%- method.link %></a></code></li>
+           <% } %>
         </ul>
     <% } %>
 <% } %>


### PR DESCRIPTION
@garg3133 Review Requested for Fix Issue #293

As per my recent investigations on #289, I implemented same method of `if-else html escaped rendering` for links, and it solves the issue.

I did:

- Add WEBDRIVER_SPEC URL in `/postdoc.config.js` and export it in appSettings.
- Import appSettings in the `if-else` when link do not have http as protocol

Do let me know if this works, or should I look for other way around.
