### PR TITLE
Add docs mentioning integration with Cloud Provider TestingBot

### DIFF
--- a/docs/guide/overview/what-is-nightwatch.md
+++ b/docs/guide/overview/what-is-nightwatch.md
@@ -39,7 +39,7 @@ Internally, Nightwatch uses the [W3C WebDriver API][6] to perform the browser au
 
 Nightwatch can also be used for distributed cross-browser end-to-end testing at scale together with the [Selenium Server][13] (also known as **Selenium Grid**), which is an open-source project written in Java that manages a network of WebDriver nodes.
 
-Nightwatch also can be integrated with cloud-based testing platforms like [Browserstack][14], [SauceLabs][15], [CrossBrowserTesting][16], or [LambdaTest][17].
+Nightwatch also can be integrated with cloud-based testing platforms like [Browserstack][14], [SauceLabs][15], [CrossBrowserTesting][16], [LambdaTest][17] or [TestingBot][20].
 
 ![Selenium Server Operation][image-2]
 
@@ -104,6 +104,7 @@ WebDriver is implemented by all major browser vendors as a W3C compliant HTTP se
 [17]:   https://www.lambdatest.com/
 [18]:   https://selenium.dev/downloads/
 [19]:   https://selenium.dev/downloads/
+[20]:   https://testingbot.com/
 
 [image-1]:  /img/operation.png
 [image-2]:  /img/operation-cloud.png

--- a/docs/guide/overview/what-is-webdriver.md
+++ b/docs/guide/overview/what-is-webdriver.md
@@ -24,6 +24,7 @@ description: Webdriver is a general purpose library for automating web browsers
 [17]:   https://www.lambdatest.com/
 [18]:	https://selenium.dev/downloads/
 [19]:	https://selenium.dev/downloads/
+[20]: https://testingbot.com/
 
 [image-1]:	/img/operation.png
 [image-2]:	/img/operation-cloud.png

--- a/docs/guide/quickstarts/create-and-run-a-test-with-cloud-providers.md
+++ b/docs/guide/quickstarts/create-and-run-a-test-with-cloud-providers.md
@@ -179,6 +179,56 @@ If you are trying to run Nightwatch on Sauce Labs for an existing project, you w
 
 Once the Sauce Labs block is present in the Nightwatch configuration file, replace the Sauce Labs username and access key with your credentials.
 
+### Running on TestingBot
+
+You can use TestingBot to run Nightwatch tests on browsers in the cloud. You will need to add a `testingbot` block in the `nightwatch.conf.js` file as a child property to `test_settings`.
+
+<div class="sample-test">
+<i>nightwatch.conf.js</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
+    ...,
+    test_settings: {
+        ...,
+        testingbot: {
+            selenium: {
+                host: 'hub.testingbot.com',
+                port: 443
+            },
+            'username': '${TB_KEY}',
+            'access_key': '${TB_SECRET}',
+        },
+        'testingbot.chrome': {
+            extends: 'testingbot',
+            desiredCapabilities: {
+                browserName: 'chrome',
+                'tb:options': {
+                    'platformName': 'Windows 10',
+                    'version': 'latest',
+                    'name': 'First Nightwatch test',
+                }
+            }
+        },
+        <br>
+        'testingbot.firefox': {
+            extends: 'testingbot',
+            desiredCapabilities: {
+                browserName: 'firefox',
+                'tb:options': {
+                    'platformName': 'Windows 10',
+                    'version': 'latest',
+                    'name': 'First Nightwatch test',
+                }
+            }
+        },
+        ...
+    }
+}
+</code></pre>
+</div>
+
+After you've added the TestingBot configuration(s) in `nightwatch.conf.js`, please replace the TestingBot username and access_key with your credentials, which are available in the TestingBot member area.
+
+There are other [capabilities](https://testingbot.com/support/other/test-options) you can use to customize your tests on TestingBot.
+
 ### Running on remote Selenium server
 
 If you are installing Nightwatch using the `create-nightwatch` utility and you select to run against a remote selenium server or other cloud providers, the remote host settings will be automatically added to test_settings with place holder values.

--- a/docs/guide/reference/settings.md
+++ b/docs/guide/reference/settings.md
@@ -602,7 +602,7 @@ If you'd like to enable this, set `start_process` to `true` and specify the loca
 
 If Selenium Server is being used, then the connection related settings should be placed under the `"selenium""`. If both `webdriver` and `selenium` dictionaries are present, the `selenium` options will be merged with the `webdriver` ones.
 
-The `"selenium"` settings should also be used when configuring connections to cloud-based testing providers, such as [BrowserStack][1], [SauceLabs][2], [CrossBrowserTesting][3], or [LambdaTest][4].
+The `"selenium"` settings should also be used when configuring connections to cloud-based testing providers, such as [BrowserStack][1], [SauceLabs][2], [CrossBrowserTesting][3], [LambdaTest][4] or [TestingBot][11].
 
 <table class="table table-bordered table-striped">
 <thead>
@@ -827,6 +827,7 @@ Remember to also enable HTTP keepalive for improved network performance.
 [8]:    https://www.npmjs.com/package/iedriver
 [9]:    https://browserstack.com
 [10]:   https://www.npmjs.com/package/dotenv
+[11]:   https://testingbot.com/
 
 ### Recommended content
 


### PR DESCRIPTION
Hi,

This PR includes TestingBot as a cloud provider capable of running remote browser tests with Nightwatch.
We've had this documentation for several years on https://testingbot.com/support/getting-started/nightwatch.html#start

Would appreciate if you could include it in your documentation, thanks!

Jochen