### PR TITLE
Fixes #335 : make table responsive on web-driver-setting page

### DIFF
--- a/docs/guide/configuration/web-driver-settings.md
+++ b/docs/guide/configuration/web-driver-settings.md
@@ -10,6 +10,8 @@ Below are a number of options for the Webdriver service. Nightwatch can start an
 
 If you'd like to enable this, set `start_process` to `true` and specify the location of the binary file inside `server_path`.
 
+<div class="container">
+<div class="table-responsive">
 <table class="table table-bordered table-striped">
 <thead>
  <tr>
@@ -159,6 +161,7 @@ If you'd like to enable this, set `start_process` to `true` and specify the loca
 
  </tbody>
 </table>
+</div>
 
 
 ### Recommended content
@@ -184,4 +187,5 @@ If you'd like to enable this, set `start_process` to `true` and specify the loca
         <span>→</span>
     </a>
   </div>
+</div>
 </div>


### PR DESCRIPTION
fixed #335  by @harshal050
Description:
This PR improves the responsiveness of the (https://nightwatchjs.org/guide/configuration/web-driver-settings.html) page by integrating Bootstrap and making necessary HTML and CSS adjustments.

* Implementation Details:
1. Wrapped the table inside a div with the table-responsive class.
2. Applied Bootstrap's table and table-responsive classes for a consistent look.

* Testing:
1. Verified responsiveness on devices with different screen sizes (mobile, tablet, desktop).
2. Ensured the table scrolls horizontally on smaller screens without breaking the layout.
3. Confirmed no visual regressions on large screens.


Here's how the page looks now on mobile devices:
![Screenshot 2025-01-02 215700](https://github.com/user-attachments/assets/4169cc2b-0db5-458f-82fa-808c080885a4)
