### PR TITLE
Fixes #314 : Removed Redundant Line in baseUrl Definition

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -97,8 +97,6 @@ Below is a list of all public properties and methods that are made available on 
 
   Type: `string`
 
-  Returns `true`|`false` whether or not the browser used is Opera.
-
   The value of `baseUrl` as defined in the Nightwatch config and which will be used as the default url for the command `.init()`.
   Other aliases are: `base_url`, `launch_url`, or `launchUrl`.
 


### PR DESCRIPTION
Fixes #314 

## Description
This PR resolves an issue in the API documentation where the `baseUrl` section contained a redundant return line. The updated documentation ensures clarity and eliminates unnecessary repetition.

## Changes Made
- Updated the `baseUrl` documentation to be concise and removed the redundant line.

### Before
```markdown
#### isOpera

  Type: function isOpera(): boolean

  Returns true|false whether or not the browser used is Opera.

#### baseUrl

  Type: string

  Returns true|false whether or not the browser used is Opera.
```

### After 
```markdown
#### isOpera

  Type: function isOpera(): boolean

  Returns true|false whether or not the browser used is Opera.

#### baseUrl

  Type: string

 The value of `baseUrl` as defined in the Nightwatch config and which will be used as the default url for the command `.init()`.
  Other aliases are: `base_url`, `launch_url`, or `launchUrl`.
```
