### PR TITLE
Fixes #342: Update Footer to Display Dynamic Year in Nightwatch Website

### DIFF
--- a/src/includes/footer.ejs
+++ b/src/includes/footer.ejs
@@ -330,7 +330,7 @@
       <div class="footer__wrapper-bottom-text">
         <p class="footer__wrapper-bottom-text-about">Nightwatch was established in 2014 and since 2021 it is actively maintained at <a href="https://browserstack.com/" target="_blank" rel="noopener noreferrer">BrowserStack</a> with the help of all our <a href="https://github.com/nightwatchjs/nightwatch/graphs/contributors" target="_blank" rel="noopener noreferrer">contributors</a>.</p>
 
-        <p class="footer__wrapper-bottom-text-copywright">&copy; 2023 <a href="https://browserstack.com/" target="_blank"
+        <p class="footer__wrapper-bottom-text-copywright">&copy; <%= new Date().getFullYear() %> <a href="https://browserstack.com/" target="_blank"
             rel="noopener noreferrer">BrowserStack</a> Limited • Code licensed under the
           <a href="https://github.com/nightwatchjs/nightwatch/blob/main/LICENSE.md" target="_blank" rel="noopener noreferrer">MIT License</a>.
         </p>


### PR DESCRIPTION
Fixes #342 
### Description:
This PR updates the footer of the Nightwatch.js website to dynamically display the current year. The current implementation has a static "© 2023" text, which gives the impression that the website is outdated. The new implementation ensures the year is automatically updated using EJS.

### Changes Made:
- Updated the EJS template for the footer to dynamically render the current year using JavaScript's `Date` object.
- Code snippet added:
  ```ejs
  <footer>
    <p>© <%= new Date().getFullYear() %> Nightwatch.js. All rights reserved.</p>
  </footer>
