### PR TITLE
Fixed minor spelling mistake within "Global Test Hooks" documentation

### DIFF
--- a/docs/guide/writing-tests/global-test-hooks.md
+++ b/docs/guide/writing-tests/global-test-hooks.md
@@ -74,7 +74,7 @@ The methods are defined in the external `globals` file and invoked using the `gl
     return Promise.resolve();
   },
   <br>
-  // Called right before the command .quite() is finished
+  // Called right before the command .quit() is finished
   async onBrowserQuit(browser) {
     return Promise.resolve();
 };</code></pre></div>


### PR DESCRIPTION
Summary of Changes:
1. Fixed documentation refering to `.quite()` instead of `.quit()`