### PR TITLE
Revert "CSS Misalignment in Guide Section – Overlapping Side Panel"

### DIFF
--- a/postdoc.config.js
+++ b/postdoc.config.js
@@ -43,7 +43,6 @@ export default {
   apidocs: {
     source: API_DOCS_FOLDER,
     layout: 'api/index.ejs',
-    source: '/path/to/nightwatch/lib/api/',
 
     createUrl(filePath) {
       const fileName = basename(filePath, extname(filePath));

--- a/public/css/sidebar.css
+++ b/public/css/sidebar.css
@@ -449,7 +449,7 @@ body.navbar-visible .bs-sidebar {
 
 .right-side-nav {
   position: fixed;
-  right: 5px;
+  right: 10px;
   top: 120px;
 }
 
@@ -459,7 +459,6 @@ body.navbar-visible .bs-sidebar {
   padding-top: 10px;
   padding-left: 0;
   padding-right: 0px;
-  
 }
 
 /* @media screen and (max-width: 1400px) {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1244,11 +1244,12 @@ html {
 .doc-sideNav {
   top: 50px;
   padding-top: 50px;
-  /* position: static; */
+  position: sticky;
   height: 100%;
   padding-right: 0;
   padding-left: 0;
 }
+
 .doc-sideNav ul {
   list-style-type: none;
   padding-left: 20px;
@@ -2473,7 +2474,6 @@ section.secondary h1.community-support-title {
 
 .doc-container.full-width .doc-main-body {
   border-right: 1px solid #F6F6F6;
-  max-width: 60%;
 }
 
 .doc-main-body h1,

--- a/src/includes/rightSidebarContent.ejs
+++ b/src/includes/rightSidebarContent.ejs
@@ -7,7 +7,7 @@ const content = [...pageContent.matchAll(/<h3[^>]*id="([^"]+)".*?>(?:<a[^>]*>([^
                 }));
 %>
 
-<div class="wrapper22" style="position: static;">
+<div class="wrapper">
     <h5>On this page</h5>
     <nav class="main-side-nav">
         <% content.forEach(({ id, title }) => { %>

--- a/src/includes/sections/guide.ejs
+++ b/src/includes/sections/guide.ejs
@@ -417,7 +417,7 @@
             </div>
 
             <div class="d-none d-xl-block col-xl-2 doc-sideNav right-side-nav">
-                <div class="wrapper" style="background-color: blueviolet;">
+                <div class="wrapper">
                     <h5>On this page</h5>
                     <nav class="main-side-nav">
                         <% rightSidebarContent.forEach(({ id, title }) => { %>


### PR DESCRIPTION
Reverts nightwatchjs/nightwatch-docs#357

The PR was not properly created (contains some bad code) and the issue it solved is also not a priority.

Plus, the deploy fails after merging this PR.