### PR TITLE
fixed-link-selector

### DIFF
--- a/docs/guide/writing-tests/selectors.md
+++ b/docs/guide/writing-tests/selectors.md
@@ -180,10 +180,10 @@ Now that you understand selectors, you can use them to write commands & assertio
     </a>
   </div>
   <div class="next">
-    <a href="/guide/writing-tests/selectors.html">
+    <a href="/guide/writing-tests/adding-assertions.html">
         <div class="d-flex flex-column">
           <span class="smallT">Next Page</span>
-          <span class="bigT">Selectors</span>
+          <span class="bigT">Adding assertions to tests</span>
         </div>
         <span>→</span>
     </a>


### PR DESCRIPTION
Fixes #4399

This pull request addresses [nightwatchjs/nightwatch#4399](https://github.com/nightwatchjs/nightwatch/issues/4399)


The "Next Page" link at the bottom of the Selectors documentation page was incorrectly pointing to the same page, causing it to reload instead of navigating to the next guide section.

Steps to Reproduce:

 1)Navigate to the Selectors documentation page.
 2)Scroll down to the bottom.
 3)Click on the "Next Page" link.
 4)Observe that it reloads the same page instead of moving forward.

Fix:
Updated the "Next Page" link URL to correctly point to the next guide section i.e assertions, ensuring smooth navigation through the documentation.