### PR TITLE
Add documentation for `disable_output_boxes` config

### DIFF
--- a/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
@@ -92,7 +92,6 @@ Once you push your changes and click on save and run button, the pipeline will s
 <div class="alert alert-warning">
 <strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
- 
 Related articles
 - [How-to guides > Write tests > Run on CI Servers > Jenkins ](/guide/ci-integrations/run-nightwatch-on-jenkins.html)
 

--- a/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
@@ -90,7 +90,7 @@ Once you push your changes and click on save and run button, the pipeline will s
 **Note:** ***After saving and running, you may encounter an error stating that no hosted parallelism has been purchased or granted. Please fill out the [form](https://aka.ms/azpipelines-parallelism-request) to request a free parallelism grant.***
 
 <div class="alert alert-warning">
-<strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+  <strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
 Related articles
 - [How-to guides > Write tests > Run on CI Servers > Jenkins ](/guide/ci-integrations/run-nightwatch-on-jenkins.html)

--- a/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
@@ -92,8 +92,9 @@ Once you push your changes and click on save and run button, the pipeline will s
 <div class="alert alert-warning">
   <strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
+
 Related articles
-- [How-to guides > Write tests > Run on CI Servers > Jenkins ](/guide/ci-integrations/run-nightwatch-on-jenkins.html)
+- [How-to guides > Write tests > Run on CI Servers > Jenkins](/guide/ci-integrations/run-nightwatch-on-jenkins.html)
 
 <div class="doc-pagination pt-40">
   <div class="previous">

--- a/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
@@ -93,7 +93,7 @@ Once you push your changes and click on save and run button, the pipeline will s
   <strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
 
-Related articles
+### Related articles
 - [How-to guides > Write tests > Run on CI Servers > Jenkins](/guide/ci-integrations/run-nightwatch-on-jenkins.html)
 
 <div class="doc-pagination pt-40">

--- a/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
@@ -90,7 +90,7 @@ Once you push your changes and click on save and run button, the pipeline will s
 **Note:** ***After saving and running, you may encounter an error stating that no hosted parallelism has been purchased or granted. Please fill out the [form](https://aka.ms/azpipelines-parallelism-request) to request a free parallelism grant.***
 
 <div class="alert alert-warning">
-If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+<strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
  
 Related articles

--- a/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-azure-pipelines.md
@@ -89,6 +89,9 @@ Once you push your changes and click on save and run button, the pipeline will s
 
 **Note:** ***After saving and running, you may encounter an error stating that no hosted parallelism has been purchased or granted. Please fill out the [form](https://aka.ms/azpipelines-parallelism-request) to request a free parallelism grant.***
 
+<div class="alert alert-warning">
+If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
  
 Related articles
 - [How-to guides > Write tests > Run on CI Servers > Jenkins ](/guide/ci-integrations/run-nightwatch-on-jenkins.html)

--- a/docs/guide/ci-integrations/run-nightwatch-on-bamboo.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-bamboo.md
@@ -87,6 +87,9 @@ After installation, now you can sign in to the admin and create a plan after cli
 
 ![Bamboo-results](https://user-images.githubusercontent.com/94462364/184720721-734423c4-bd4d-4efc-b265-304792e77473.png)
 
+<div class="alert alert-warning">
+If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
 
 ### Related articles
 - [How-to guides > Write tests > Run on CI Servers > Jenkins ](/guide/ci-integrations/run-nightwatch-on-jenkins.html)

--- a/docs/guide/ci-integrations/run-nightwatch-on-bamboo.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-bamboo.md
@@ -88,7 +88,7 @@ After installation, now you can sign in to the admin and create a plan after cli
 ![Bamboo-results](https://user-images.githubusercontent.com/94462364/184720721-734423c4-bd4d-4efc-b265-304792e77473.png)
 
 <div class="alert alert-warning">
-If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+<strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
 
 ### Related articles

--- a/docs/guide/ci-integrations/run-nightwatch-on-circleci.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-circleci.md
@@ -78,7 +78,7 @@ Click on the pipeline build that just ran followed by the job name i.e. `test`. 
 ![Circle CI Results](https://user-images.githubusercontent.com/1677755/189831161-c08ee3e0-e1ce-4e92-90be-92c1ab61e02b.png)
 
 <div class="alert alert-warning">
-If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+<strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
 
 ### Related articles

--- a/docs/guide/ci-integrations/run-nightwatch-on-circleci.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-circleci.md
@@ -77,6 +77,9 @@ Click on the pipeline build that just ran followed by the job name i.e. `test`. 
 
 ![Circle CI Results](https://user-images.githubusercontent.com/1677755/189831161-c08ee3e0-e1ce-4e92-90be-92c1ab61e02b.png)
 
+<div class="alert alert-warning">
+If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
 
 ### Related articles
 - [How-to guides > Write tests > Run on CI Servers > Jenkins ](/guide/ci-integrations/run-nightwatch-on-jenkins.html)

--- a/docs/guide/ci-integrations/run-nightwatch-on-github-actions.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-github-actions.md
@@ -73,6 +73,9 @@ You can either skip the above steps and can also directly push your .yml from lo
 #### Step 4: How to run the tests?
 Once you push your changes to Github and will raise a Pull Request the pipeline will start and your tests will run automatically.
 
+<div class="alert alert-warning">
+If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
 
 ### Related articles
  

--- a/docs/guide/ci-integrations/run-nightwatch-on-github-actions.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-github-actions.md
@@ -74,7 +74,7 @@ You can either skip the above steps and can also directly push your .yml from lo
 Once you push your changes to Github and will raise a Pull Request the pipeline will start and your tests will run automatically.
 
 <div class="alert alert-warning">
-If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+<strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
 
 ### Related articles

--- a/docs/guide/ci-integrations/run-nightwatch-on-gitlab.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-gitlab.md
@@ -122,6 +122,9 @@ You can view the execution output in the shell logs of the particular pipeline r
 
 ![Gitlab CI Results](https://user-images.githubusercontent.com/1677755/191442560-0973bf79-8b45-4a25-bb34-44f72757554a.png)
 
+<div class="alert alert-warning">
+If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
 
 ### Related articles
 - [How-to guides > Write tests > Run on CI Servers > Jenkins ](/guide/ci-integrations/run-nightwatch-on-jenkins.html)

--- a/docs/guide/ci-integrations/run-nightwatch-on-gitlab.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-gitlab.md
@@ -123,7 +123,7 @@ You can view the execution output in the shell logs of the particular pipeline r
 ![Gitlab CI Results](https://user-images.githubusercontent.com/1677755/191442560-0973bf79-8b45-4a25-bb34-44f72757554a.png)
 
 <div class="alert alert-warning">
-If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+<strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
 
 ### Related articles

--- a/docs/guide/ci-integrations/run-nightwatch-on-jenkins.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-jenkins.md
@@ -69,6 +69,10 @@ The setup is done. You can execute the tests by updating the test exection shell
 
 Once you build, the tests will be executed on BrowserStack.
 
+<div class="alert alert-warning">
+If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
+
 ### View JUnit XML reports
 Nightwatch publishes XML reports after test-run the same can be used in Jenkins to publish test reports.
 

--- a/docs/guide/ci-integrations/run-nightwatch-on-jenkins.md
+++ b/docs/guide/ci-integrations/run-nightwatch-on-jenkins.md
@@ -70,7 +70,7 @@ The setup is done. You can execute the tests by updating the test exection shell
 Once you build, the tests will be executed on BrowserStack.
 
 <div class="alert alert-warning">
-If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments, see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+<strong>Known Issue:</strong> When running tests in parallel mode in CI environments, line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
 
 ### View JUnit XML reports

--- a/docs/guide/configuration/customising-test-output.md
+++ b/docs/guide/configuration/customising-test-output.md
@@ -124,8 +124,7 @@ These settings can be added at the top level of your Nightwatch config (same lev
     <td><code>disable_output_boxes</code></td>
     <td>boolean</td>
     <td>false</td>
-    <td>Set this to true if you'd like to disable bounding boxes on terminal output.<br> <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. This issue does not occur when running locally. See <a href="https://github.com/nightwatchjs/nightwatch/issues/4396" target="_blank">issue #4396</a> for more details.
-</td>
+    <td>Set this to true if you'd like to disable bounding boxes on terminal output.</td>
   </tr>      
   </tbody>
 </table>

--- a/docs/guide/configuration/customising-test-output.md
+++ b/docs/guide/configuration/customising-test-output.md
@@ -125,7 +125,7 @@ These settings can be added at the top level of your Nightwatch config (same lev
     <td>boolean</td>
     <td>false</td>
     <td>Set this to true if you'd like to disable bounding boxes on terminal output.</td>
-  </tr>      
+  </tr>
   </tbody>
 </table>
 

--- a/docs/guide/configuration/customising-test-output.md
+++ b/docs/guide/configuration/customising-test-output.md
@@ -124,7 +124,7 @@ These settings can be added at the top level of your Nightwatch config (same lev
     <td><code>disable_output_boxes</code></td>
     <td>boolean</td>
     <td>false</td>
-    <td>Set this to true if you'd like to disable bounding boxes on terminal output.</td>
+    <td>Set this to true to disable bounding boxes around testsuite terminal output. This can resolve missing line break issues in CI environments when running tests in parallel mode.</td>
   </tr>
   </tbody>
 </table>

--- a/docs/guide/configuration/customising-test-output.md
+++ b/docs/guide/configuration/customising-test-output.md
@@ -85,7 +85,44 @@ The below settings can be used to control the output and logging when running te
     <td>boolean</td>
     <td>false</td>
     <td>Used to enable showing the Base64 image data in the (verbose) log when taking screenshots.</td>
-  </tr>         
+  </tr>
+  <tr>
+    <td><code>disable_output_boxes</code></td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>Set this to true if you'd like to disable bounding boxes on terminal output.<br> <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. This issue does not occur when running locally. See <a href="https://github.com/nightwatchjs/nightwatch/issues/4396" target="_blank">issue #4396</a> for more details. Following either of the examples below will solve this problem:
+      <ul>
+        <li>Set <code>disable_output_boxes: true</code> at the top level of your Nightwatch config (same level as <code>src_folders</code>):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
+  src_folders: ['tests'],
+  disable_output_boxes: true,
+  
+      test_settings: {
+        default: {
+          // ... your settings
+        }
+      }
+    };
+  </code>
+  </pre>
+  </li>
+        <li>Set <code>disable_output_boxes: true</code> inside a specific environment object (e.g., inside the <code>chrome</code> environment if you use separate environments for CI):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
+  src_folders: ['tests'],
+  
+      test_settings: {
+        chrome: {
+          disable_output_boxes: true,
+          desiredCapabilities: {
+            browserName: 'chrome'
+          }
+        }
+      }
+    };
+  </code>
+  </pre>
+  </li>
+      </ul>
+</td>
+  </tr>      
   </tbody>
 </table>
 

--- a/docs/guide/configuration/customising-test-output.md
+++ b/docs/guide/configuration/customising-test-output.md
@@ -7,6 +7,40 @@ description: Learn how to customize output settings in Nightwatch.
 
 The below settings can be used to control the output and logging when running tests.
 
+These settings can be added at the top level of your Nightwatch config (same level as <code>src_folders</code>) or inside a specific environment object within <code>test_settings</code>. When set at the top level, they apply to all environments. When set inside a specific environment, they only apply to that environment.
+
+**Examples:**
+<ul>
+  <li>Set <code>disable_output_boxes: true</code> at the top level of your Nightwatch config (same level as <code>src_folders</code>):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
+  src_folders: ['tests'],
+  disable_output_boxes: true,
+  
+      test_settings: {
+        default: {
+          // ... your settings
+        }
+      }
+    };
+</code>
+</pre>
+</li>
+  <li>Set <code>disable_output_boxes: true</code> inside a specific environment object (e.g., inside the <code>chrome</code> environment if you use separate environments for CI):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
+  src_folders: ['tests'],
+  
+      test_settings: {
+        chrome: {
+          disable_output_boxes: true,
+          desiredCapabilities: {
+            browserName: 'chrome'
+          }
+        }
+      }
+    };
+</code>
+</pre>
+</li>
+</ul>
+
 <table class="table table-bordered table-striped">
   <thead>
    <tr>
@@ -90,37 +124,7 @@ The below settings can be used to control the output and logging when running te
     <td><code>disable_output_boxes</code></td>
     <td>boolean</td>
     <td>false</td>
-    <td>Set this to true if you'd like to disable bounding boxes on terminal output.<br> <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. This issue does not occur when running locally. See <a href="https://github.com/nightwatchjs/nightwatch/issues/4396" target="_blank">issue #4396</a> for more details. Following either of the examples below will solve this problem:
-      <ul>
-        <li>Set <code>disable_output_boxes: true</code> at the top level of your Nightwatch config (same level as <code>src_folders</code>):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
-  src_folders: ['tests'],
-  disable_output_boxes: true,
-  
-      test_settings: {
-        default: {
-          // ... your settings
-        }
-      }
-    };
-  </code>
-  </pre>
-  </li>
-        <li>Set <code>disable_output_boxes: true</code> inside a specific environment object (e.g., inside the <code>chrome</code> environment if you use separate environments for CI):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
-  src_folders: ['tests'],
-  
-      test_settings: {
-        chrome: {
-          disable_output_boxes: true,
-          desiredCapabilities: {
-            browserName: 'chrome'
-          }
-        }
-      }
-    };
-  </code>
-  </pre>
-  </li>
-      </ul>
+    <td>Set this to true if you'd like to disable bounding boxes on terminal output.<br> <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. This issue does not occur when running locally. See <a href="https://github.com/nightwatchjs/nightwatch/issues/4396" target="_blank">issue #4396</a> for more details.
 </td>
   </tr>      
   </tbody>

--- a/docs/guide/reference/settings.md
+++ b/docs/guide/reference/settings.md
@@ -480,7 +480,7 @@ These settings can be added at the top level of your Nightwatch config (same lev
     <td>boolean</td>
     <td>false</td>
     <td>Set this to true if you'd like to disable bounding boxes on terminal output.</td>
-  </tr> 
+  </tr>
   </tbody>
 </table>
 

--- a/docs/guide/reference/settings.md
+++ b/docs/guide/reference/settings.md
@@ -375,6 +375,41 @@ The below settings can be used to define ways of filtering test files.
 ### Output Settings
 
 The below settings can be used to control the output and logging when running tests.
+
+These settings can be added at the top level of your Nightwatch config (same level as <code>src_folders</code>) or inside a specific environment object within <code>test_settings</code>. When set at the top level, they apply to all environments. When set inside a specific environment, they only apply to that environment.
+
+**Examples:**
+<ul>
+  <li>Set <code>disable_output_boxes: true</code> at the top level of your Nightwatch config (same level as <code>src_folders</code>):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
+  src_folders: ['tests'],
+  disable_output_boxes: true,
+  
+      test_settings: {
+        default: {
+          // ... your settings
+        }
+      }
+    };
+</code>
+</pre>
+</li>
+  <li>Set <code>disable_output_boxes: true</code> inside a specific environment object (e.g., inside the <code>chrome</code> environment if you use separate environments for CI):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
+  src_folders: ['tests'],
+  
+      test_settings: {
+        chrome: {
+          disable_output_boxes: true,
+          desiredCapabilities: {
+            browserName: 'chrome'
+          }
+        }
+      }
+    };
+</code>
+</pre>
+</li>
+</ul>
+
 <table class="table table-bordered table-striped">
   <thead>
    <tr>
@@ -444,38 +479,8 @@ The below settings can be used to control the output and logging when running te
     <td><code>disable_output_boxes</code></td>
     <td>boolean</td>
     <td>false</td>
-    <td>Set this to true if you'd like to disable bounding boxes on terminal output.<br> <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. This issue does not occur when running locally. See <a href="https://github.com/nightwatchjs/nightwatch/issues/4396" target="_blank">issue #4396</a> for more details. Following either of the examples below will solve this problem:
-      <ul>
-        <li>Set <code>disable_output_boxes: true</code> at the top level of your Nightwatch config (same level as <code>src_folders</code>):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
-  src_folders: ['tests'],
-  disable_output_boxes: true,
-  
-      test_settings: {
-        default: {
-          // ... your settings
-        }
-      }
-    };
-  </code>
-  </pre>
-  </li>
-        <li>Set <code>disable_output_boxes: true</code> inside a specific environment object (e.g., inside the <code>chrome</code> environment if you use separate environments for CI):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
-  src_folders: ['tests'],
-  
-      test_settings: {
-        chrome: {
-          disable_output_boxes: true,
-          desiredCapabilities: {
-            browserName: 'chrome'
-          }
-        }
-      }
-    };
-  </code>
-  </pre>
-  </li>
-      </ul>
-</td>
+    <td>Set this to true if you'd like to disable bounding boxes on terminal output.<br> <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. This issue does not occur when running locally. See <a href="https://github.com/nightwatchjs/nightwatch/issues/4396" target="_blank">issue #4396</a> for more details.
+    </td>
   </tr> 
   </tbody>
 </table>

--- a/docs/guide/reference/settings.md
+++ b/docs/guide/reference/settings.md
@@ -479,7 +479,7 @@ These settings can be added at the top level of your Nightwatch config (same lev
     <td><code>disable_output_boxes</code></td>
     <td>boolean</td>
     <td>false</td>
-    <td>Set this to true if you'd like to disable bounding boxes on terminal output.</td>
+    <td>Set this to true to disable bounding boxes around testsuite terminal output. This can resolve missing line break issues in CI environments when running tests in parallel mode.</td>
   </tr>
   </tbody>
 </table>

--- a/docs/guide/reference/settings.md
+++ b/docs/guide/reference/settings.md
@@ -479,8 +479,7 @@ These settings can be added at the top level of your Nightwatch config (same lev
     <td><code>disable_output_boxes</code></td>
     <td>boolean</td>
     <td>false</td>
-    <td>Set this to true if you'd like to disable bounding boxes on terminal output.<br> <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. This issue does not occur when running locally. See <a href="https://github.com/nightwatchjs/nightwatch/issues/4396" target="_blank">issue #4396</a> for more details.
-    </td>
+    <td>Set this to true if you'd like to disable bounding boxes on terminal output.</td>
   </tr> 
   </tbody>
 </table>

--- a/docs/guide/reference/settings.md
+++ b/docs/guide/reference/settings.md
@@ -439,6 +439,44 @@ The below settings can be used to control the output and logging when running te
     <td>false</td>
     <td>Used to enable showing the Base64 image data in the (verbose) log when taking screenshots.</td>
   </tr>
+
+  <tr>
+    <td><code>disable_output_boxes</code></td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>Set this to true if you'd like to disable bounding boxes on terminal output.<br> <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. This issue does not occur when running locally. See <a href="https://github.com/nightwatchjs/nightwatch/issues/4396" target="_blank">issue #4396</a> for more details. Following either of the examples below will solve this problem:
+      <ul>
+        <li>Set <code>disable_output_boxes: true</code> at the top level of your Nightwatch config (same level as <code>src_folders</code>):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
+  src_folders: ['tests'],
+  disable_output_boxes: true,
+  
+      test_settings: {
+        default: {
+          // ... your settings
+        }
+      }
+    };
+  </code>
+  </pre>
+  </li>
+        <li>Set <code>disable_output_boxes: true</code> inside a specific environment object (e.g., inside the <code>chrome</code> environment if you use separate environments for CI):<br><pre data-language="javascript"><code class="language-javascript">module.exports = {
+  src_folders: ['tests'],
+  
+      test_settings: {
+        chrome: {
+          disable_output_boxes: true,
+          desiredCapabilities: {
+            browserName: 'chrome'
+          }
+        }
+      }
+    };
+  </code>
+  </pre>
+  </li>
+      </ul>
+</td>
+  </tr> 
   </tbody>
 </table>
 

--- a/docs/guide/running-tests/parallel-running.md
+++ b/docs/guide/running-tests/parallel-running.md
@@ -45,6 +45,10 @@ Test concurrency is done at the file level. Each test file will fill a test work
 To improve support for displaying the output when running tests in parallel, we recommend setting <code>detailed_output</code> to <code>false</code> in your test settings (and also make sure <code>live_output</code> is enabled).
 </div>
 
+<div class="alert alert-warning">
+<strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
+
 ### Multiple environments
 
 Nightwatch supports running tests across multiple browsers in parallel. The below command will run two environments named `firefox` and `chrome` in parallel:
@@ -74,10 +78,6 @@ From **v1.7** you are able to do just that.
 <pre><code class="language-bash">nightwatch -e firefox,chrome --workers=4</code></pre>
 
 The above will run two environments named `firefox` and `chrome` in parallel.
-
-<div class="alert alert-warning">
-If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments (such as GitLab CI), see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
-</div>
 
 ### Recommended content
 - [Define and use test environments](/guide/configuration/define-test-environments.html)

--- a/docs/guide/running-tests/parallel-running.md
+++ b/docs/guide/running-tests/parallel-running.md
@@ -45,6 +45,10 @@ Test concurrency is done at the file level. Each test file will fill a test work
 To improve support for displaying the output when running tests in parallel, we recommend setting <code>detailed_output</code> to <code>false</code> in your test settings (and also make sure <code>live_output</code> is enabled).
 </div>
 
+<div class="alert alert-warning">
+If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments (such as GitLab CI), see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
+
 ### Multiple environments
 
 Nightwatch supports running tests across multiple browsers in parallel. The below command will run two environments named `firefox` and `chrome` in parallel:

--- a/docs/guide/running-tests/parallel-running.md
+++ b/docs/guide/running-tests/parallel-running.md
@@ -45,10 +45,6 @@ Test concurrency is done at the file level. Each test file will fill a test work
 To improve support for displaying the output when running tests in parallel, we recommend setting <code>detailed_output</code> to <code>false</code> in your test settings (and also make sure <code>live_output</code> is enabled).
 </div>
 
-<div class="alert alert-warning">
-If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments (such as GitLab CI), see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
-</div>
-
 ### Multiple environments
 
 Nightwatch supports running tests across multiple browsers in parallel. The below command will run two environments named `firefox` and `chrome` in parallel:
@@ -78,6 +74,10 @@ From **v1.7** you are able to do just that.
 <pre><code class="language-bash">nightwatch -e firefox,chrome --workers=4</code></pre>
 
 The above will run two environments named `firefox` and `chrome` in parallel.
+
+<div class="alert alert-warning">
+If you're experiencing missing line breaks in the output when running tests in parallel mode in CI environments (such as GitLab CI), see the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
+</div>
 
 ### Recommended content
 - [Define and use test environments](/guide/configuration/define-test-environments.html)


### PR DESCRIPTION
Issue: https://github.com/nightwatchjs/nightwatch/issues/4396
<img width="853" height="409" alt="Screenshot 2026-01-08 at 5 49 25 PM" src="https://github.com/user-attachments/assets/63a4ddcb-442a-44eb-a477-a0afcd684f54" />
<img width="816" height="113" alt="Screenshot 2026-01-08 at 5 42 58 PM" src="https://github.com/user-attachments/assets/30f24d59-136c-4189-b278-7c7c6b83a46d" />
<img width="823" height="258" alt="Screenshot 2026-01-08 at 5 42 23 PM" src="https://github.com/user-attachments/assets/5b8065a9-7287-4b03-8646-1a230502957e" />
<img width="891" height="921" alt="Screenshot 2026-01-08 at 5 41 21 PM" src="https://github.com/user-attachments/assets/9fe033bc-3f29-4785-ab06-54dd43fd9b73" />
