### PR TITLE
Document retain_logs_in_parallel_run webdriver option

### DIFF
--- a/docs/guide/configuration/web-driver-settings.md
+++ b/docs/guide/configuration/web-driver-settings.md
@@ -72,6 +72,13 @@ If you'd like to enable this, set `start_process` to `true` and specify the loca
    </tr>
 
    <tr>
+     <td><code>retain_logs_in_parallel_run</code></td>
+     <td>boolean</td>
+     <td>false</td>
+     <td>When running tests in parallel via test workers, each worker spawns its own Webdriver process but their logs are not written to disk by default. Set this to <code>true</code> to retain the Webdriver server logs from worker processes when running in parallel mode.</td>
+   </tr>
+
+   <tr>
      <td><code>cli_args</code></td>
      <td>object</td>
      <td>none</td>

--- a/docs/guide/running-tests/parallel-running.md
+++ b/docs/guide/running-tests/parallel-running.md
@@ -49,6 +49,25 @@ To improve support for displaying the output when running tests in parallel, we 
 <strong>Known Issue:</strong> When running tests in parallel mode in CI environments (such as GitLab CI), line breaks may be missing from the output, making it difficult to read. See the <code>disable_output_boxes</code> output setting in the <a href="/guide/configuration/customising-test-output.html">Test Output</a> page to resolve this.
 </div>
 
+#### Retaining Webdriver logs from workers
+
+When tests run in parallel via test workers, each worker spawns its own Webdriver process. By default, the Webdriver server logs from these worker processes are not written to disk — only the main process writes its log file. If you need the per-worker Webdriver logs (for debugging driver-level issues across workers, for example), set `retain_logs_in_parallel_run` to `true` under the `webdriver` section of your config:
+
+<div class="sample-test"><i>nightwatch.conf.js</i><pre class="line-numbers"><code class="language-javascript">module.exports = {
+  webdriver: {
+    log_path: './logs',
+    retain_logs_in_parallel_run: true
+  },
+
+  test_workers: {
+    enabled: true,
+    workers: 'auto'
+  }
+}
+</code></pre></div>
+
+With this enabled, each worker writes its own Webdriver log file to the configured `log_path`. See the <a href="/guide/configuration/web-driver-settings.html">Webdriver settings</a> reference for the full list of options.
+
 ### Multiple environments
 
 Nightwatch supports running tests across multiple browsers in parallel. The below command will run two environments named `firefox` and `chrome` in parallel:

--- a/docs/guide/running-tests/parallel-running.md
+++ b/docs/guide/running-tests/parallel-running.md
@@ -58,7 +58,6 @@ When tests run in parallel via test workers, each worker spawns its own Webdrive
     log_path: './logs',
     retain_logs_in_parallel_run: true
   },
-
   test_workers: {
     enabled: true,
     workers: 'auto'


### PR DESCRIPTION
Adds the new option to the Webdriver settings reference and a section in the parallel running guide explaining when and how to use it to retain per-worker Webdriver logs.

<img width="1174" height="380" alt="Screenshot 2026-05-10 at 9 42 44 PM" src="https://github.com/user-attachments/assets/f3c172d3-d6e0-4ce1-8c61-9485e29e0f2e" />

<img width="1263" height="714" alt="Screenshot 2026-05-10 at 9 42 34 PM" src="https://github.com/user-attachments/assets/49f2fa1a-1fb8-4c01-b98b-f73a313425b3" />
